### PR TITLE
Added gitignore to ignore vim files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.swp
+*.swo
+.env
+.DS_Store


### PR DESCRIPTION
Added a `.gitignore` file to hide your vim's `.swp` and `.swo`, along with your important `.env` and system `.DS_Store` file.

Hide's unnecessary system files that are only specific to you, files that will bloat the repo, and files with secrets on them ( `.env` ) - so everyone that interacts with this repo can always a consistent experience running the application